### PR TITLE
Allow textsecure to be easily used with an HTTP proxy

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -51,6 +51,9 @@ func newHTTPTransporter(baseURL, user, pass string, skipTLSCheck bool) *httpTran
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}
 	}
+	client.Transport = &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+	}
 
 	return &httpTransporter{baseURL, user, pass, client}
 }


### PR DESCRIPTION
This patch adds support for HTTP proxies to client.Transport
and it may be used like this:

	http_proxy=127.0.0.1:8118 ./textsecure