### PR TITLE
Allow textsecure to be easily used with an HTTP proxy

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -49,6 +49,11 @@ func newHTTPTransporter(baseURL, user, pass string, skipTLSCheck bool) *httpTran
 	if skipTLSCheck {
 		client.Transport = &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			Proxy:           http.ProxyFromEnvironment,
+		}
+	} else {
+		client.Transport = &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 		}
 	}
 


### PR DESCRIPTION
This patch adds support for HTTP proxies to client.Transport
and it may be used like this:

	http_proxy=127.0.0.1:8118 ./textsecure