### PR TITLE
check error codes returned by os.MkdirAll()

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -78,9 +78,11 @@ func loadGroup(path string) error {
 }
 
 // setupGroups reads all groups' state from storage.
-func setupGroups() {
+func setupGroups() error {
 	groupDir = filepath.Join(config.StorageDir, "groups")
-	os.MkdirAll(groupDir, 0700)
+	if err := os.MkdirAll(groupDir, 0700); err != nil {
+		return err
+	}
 	filepath.Walk(groupDir, func(path string, fi os.FileInfo, err error) error {
 		if !fi.IsDir() {
 			if !strings.Contains(path, "avatar") {
@@ -90,6 +92,7 @@ func setupGroups() {
 		return nil
 
 	})
+	return nil
 }
 
 // avatarPath returns the path to the avatar image of a given group.

--- a/prekeys.go
+++ b/prekeys.go
@@ -83,7 +83,9 @@ func getNextPreKeyID() uint32 {
 }
 
 func generatePreKeys() error {
-	os.MkdirAll(textSecureStore.preKeysDir, 0700)
+	if err := os.MkdirAll(textSecureStore.preKeysDir, 0700); err != nil {
+		return err
+	}
 
 	startID := getNextPreKeyID()
 	for i := 0; i < preKeyBatchSize; i++ {

--- a/store.go
+++ b/store.go
@@ -44,10 +44,18 @@ func newStore(password, path string) (*store, error) {
 	}
 
 	// Create dirs in case this is first run
-	os.MkdirAll(ts.preKeysDir, 0700)
-	os.MkdirAll(ts.signedPreKeysDir, 0700)
-	os.MkdirAll(ts.identityDir, 0700)
-	os.MkdirAll(ts.sessionsDir, 0700)
+	if err := os.MkdirAll(ts.preKeysDir, 0700); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(ts.signedPreKeysDir, 0700); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(ts.identityDir, 0700); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(ts.sessionsDir, 0700); err != nil {
+		return nil, err
+	}
 
 	// If there is a password, generate the keys from it
 	if !ts.unencrypted {
@@ -402,7 +410,9 @@ func setupStore() error {
 		return err
 	}
 
-	setupGroups()
+	if err := setupGroups(); err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
Gives better indication of errors to users, if a problem during the initial setup occurs.