### PR TITLE
Add support for device provisioning

### DIFF
--- a/cmd/textsecure/main.go
+++ b/cmd/textsecure/main.go
@@ -264,7 +264,7 @@ func main() {
 		}
 
 		for _, d := range devs {
-			fmt.Printf("ID: %d\n", d.ID)
+			log.Printf("ID: %d\n", d.ID)
 			log.Printf("Name: %s\n", d.Name)
 			log.Printf("Created: %d\n", d.Created)
 			log.Printf("LastSeen: %d\n", d.LastSeen)

--- a/cmd/textsecure/main.go
+++ b/cmd/textsecure/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -21,16 +22,19 @@ import (
 // or carry on a conversation with another client
 
 var (
-	echo       bool
-	to         string
-	group      bool
-	message    string
-	attachment string
-	newgroup   string
-	leavegroup string
-	endsession bool
-	configDir  string
-	stress     int
+	echo         bool
+	to           string
+	group        bool
+	message      string
+	attachment   string
+	newgroup     string
+	leavegroup   string
+	endsession   bool
+	showdevices  bool
+	linkdevice   string
+	unlinkdevice int
+	configDir    string
+	stress       int
 )
 
 func init() {
@@ -42,6 +46,9 @@ func init() {
 	flag.StringVar(&newgroup, "newgroup", "", "Create a group, the argument has the format 'name:member1:member2'")
 	flag.StringVar(&leavegroup, "leavegroup", "", "Leave a group named by the argument")
 	flag.BoolVar(&endsession, "endsession", false, "Terminate session with peer")
+	flag.BoolVar(&showdevices, "showdevices", false, "Show linked devices")
+	flag.StringVar(&linkdevice, "linkdevice", "", "Link a new device, the argument is a url in the format 'tsdevice:/?uuid=xxx&pub_key=yyy'")
+	flag.IntVar(&unlinkdevice, "unlinkdevice", 0, "Unlink a device, the argument is the id of the device to delete")
 	flag.IntVar(&stress, "stress", 0, "Automatically send many messages to the peer")
 	flag.StringVar(&configDir, "config", ".config", "Location of config dir")
 }
@@ -219,6 +226,51 @@ func main() {
 	err := textsecure.Setup(client)
 	if err != nil {
 		log.Fatal(err)
+	}
+
+	if linkdevice != "" {
+		log.Printf("Linking new device with url: %s", linkdevice)
+		url, err := url.Parse(linkdevice)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		uuid := url.Query().Get("uuid")
+		pk := url.Query().Get("pub_key")
+		code, err := textsecure.NewDeviceVerificationCode()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = textsecure.AddDevice(uuid, pk, code)
+		if err != nil {
+			log.Fatal(err)
+		}
+		return
+	}
+
+	if unlinkdevice > 0 {
+		err = textsecure.UnlinkDevice(unlinkdevice)
+		if err != nil {
+			log.Fatal(err)
+		}
+		return
+	}
+
+	if showdevices {
+		devs, err := textsecure.LinkedDevices()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		for _, d := range devs {
+			fmt.Printf("ID: %d\n", d.ID)
+			log.Printf("Name: %s\n", d.Name)
+			log.Printf("Created: %d\n", d.Created)
+			log.Printf("LastSeen: %d\n", d.LastSeen)
+			log.Println("============")
+		}
+		return
 	}
 
 	if !echo {

--- a/config.go
+++ b/config.go
@@ -11,17 +11,18 @@ import (
 
 // Config holds application configuration settings
 type Config struct {
-	Tel                string `yaml:"tel"`                // Our telephone number
-	Server             string `yaml:"server"`             // The TextSecure server URL
-	RootCA             string `yaml:"rootCA"`             // The TLS signing certificate of the server we connect to
-	ProxyServer        string `yaml:"proxy"`              // HTTP Proxy URL if one is being used
-	VerificationType   string `yaml:"verificationType"`   // Code verification method during registration (SMS/VOICE/DEV)
-	StorageDir         string `yaml:"storageDir"`         // Directory for the persistent storage
-	UnencryptedStorage bool   `yaml:"unencryptedStorage"` // Whether to store plaintext keys and session state (only for development)
-	StoragePassword    string `yaml:"storagePassword"`    // Password to the storage
-	LogLevel           string `yaml:"loglevel"`           // Verbosity of the logging messages
-	UserAgent          string `yaml:"userAgent"`          // Override for the default HTTP User Agent header field
-	AlwaysTrustPeerID  bool   `yaml:"alwaysTrustPeerID"`  // Workaround until proper handling of peer reregistering with new ID.
+	Tel                   string `yaml:"tel"`                   // Our telephone number
+	Server                string `yaml:"server"`                // The TextSecure server URL
+	RootCA                string `yaml:"rootCA"`                // The TLS signing certificate of the server we connect to
+	ProxyServer           string `yaml:"proxy"`                 // HTTP Proxy URL if one is being used
+	VerificationType      string `yaml:"verificationType"`      // Code verification method during registration (SMS/VOICE/DEV)
+	StorageDir            string `yaml:"storageDir"`            // Directory for the persistent storage
+	UnencryptedStorage    bool   `yaml:"unencryptedStorage"`    // Whether to store plaintext keys and session state (only for development)
+	StoragePassword       string `yaml:"storagePassword"`       // Password to the storage
+	LogLevel              string `yaml:"loglevel"`              // Verbosity of the logging messages
+	UserAgent             string `yaml:"userAgent"`             // Override for the default HTTP User Agent header field
+	AlwaysTrustPeerID     bool   `yaml:"alwaysTrustPeerID"`     // Workaround until proper handling of peer reregistering with new ID.
+	EnableMultiDeviceSync bool   `yaml:"enableMultiDeviceSync"` // Enable multi-device synchronization
 }
 
 // ReadConfig reads a YAML config file

--- a/config.go
+++ b/config.go
@@ -11,18 +11,17 @@ import (
 
 // Config holds application configuration settings
 type Config struct {
-	Tel                   string `yaml:"tel"`                   // Our telephone number
-	Server                string `yaml:"server"`                // The TextSecure server URL
-	RootCA                string `yaml:"rootCA"`                // The TLS signing certificate of the server we connect to
-	ProxyServer           string `yaml:"proxy"`                 // HTTP Proxy URL if one is being used
-	VerificationType      string `yaml:"verificationType"`      // Code verification method during registration (SMS/VOICE/DEV)
-	StorageDir            string `yaml:"storageDir"`            // Directory for the persistent storage
-	UnencryptedStorage    bool   `yaml:"unencryptedStorage"`    // Whether to store plaintext keys and session state (only for development)
-	StoragePassword       string `yaml:"storagePassword"`       // Password to the storage
-	LogLevel              string `yaml:"loglevel"`              // Verbosity of the logging messages
-	UserAgent             string `yaml:"userAgent"`             // Override for the default HTTP User Agent header field
-	AlwaysTrustPeerID     bool   `yaml:"alwaysTrustPeerID"`     // Workaround until proper handling of peer reregistering with new ID.
-	EnableMultiDeviceSync bool   `yaml:"enableMultiDeviceSync"` // Enable multi-device synchronization
+	Tel                string `yaml:"tel"`                // Our telephone number
+	Server             string `yaml:"server"`             // The TextSecure server URL
+	RootCA             string `yaml:"rootCA"`             // The TLS signing certificate of the server we connect to
+	ProxyServer        string `yaml:"proxy"`              // HTTP Proxy URL if one is being used
+	VerificationType   string `yaml:"verificationType"`   // Code verification method during registration (SMS/VOICE/DEV)
+	StorageDir         string `yaml:"storageDir"`         // Directory for the persistent storage
+	UnencryptedStorage bool   `yaml:"unencryptedStorage"` // Whether to store plaintext keys and session state (only for development)
+	StoragePassword    string `yaml:"storagePassword"`    // Password to the storage
+	LogLevel           string `yaml:"loglevel"`           // Verbosity of the logging messages
+	UserAgent          string `yaml:"userAgent"`          // Override for the default HTTP User Agent header field
+	AlwaysTrustPeerID  bool   `yaml:"alwaysTrustPeerID"`  // Workaround until proper handling of peer reregistering with new ID.
 }
 
 // ReadConfig reads a YAML config file

--- a/server.go
+++ b/server.go
@@ -202,7 +202,6 @@ func addNewDevice(ephemeralId, publicKey, verificationCode string) error {
 	}
 
 	url := fmt.Sprintf(provisioningMessagePath, ephemeralId)
-	fmt.Printf("ProvisionMessage Path: %s\n", url)
 	resp, err := transport.putJSON(url, body)
 	if err != nil {
 		return err

--- a/server.go
+++ b/server.go
@@ -578,7 +578,7 @@ func sendMessage(msg *outgoingMessage) (uint64, error) {
 		return 0, err
 	}
 
-	if resp.NeedsSync && config.EnableMultiDeviceSync {
+	if resp.NeedsSync {
 		log.Debugf("Needs sync. destination: %s", msg.tel)
 		sm := &textsecure.SyncMessage{
 			Sent: &textsecure.SyncMessage_Sent{

--- a/sync.go
+++ b/sync.go
@@ -20,7 +20,7 @@ func handleSyncMessage(src string, timestamp uint64, sm *textsecure.SyncMessage)
 	}
 
 	if sm.GetSent() != nil {
-		return handleSyncSent(sm.GetSent())
+		return handleSyncSent(sm.GetSent(), timestamp)
 	} else if sm.GetRequest() != nil {
 		return handleSyncRequest(sm.GetRequest())
 	} else if sm.GetRead() != nil {
@@ -33,7 +33,7 @@ func handleSyncMessage(src string, timestamp uint64, sm *textsecure.SyncMessage)
 }
 
 // handleSyncSent handles sync sent messages
-func handleSyncSent(s *textsecure.SyncMessage_Sent) error {
+func handleSyncSent(s *textsecure.SyncMessage_Sent, ts uint64) error {
 	dm := s.GetMessage()
 	dest := s.GetDestination()
 	timestamp := s.GetTimestamp()
@@ -67,7 +67,7 @@ func handleSyncSent(s *textsecure.SyncMessage_Sent) error {
 	}
 
 	if client.SyncSentHandler != nil {
-		client.SyncSentHandler(msg)
+		client.SyncSentHandler(msg, ts)
 	}
 
 	return nil

--- a/sync.go
+++ b/sync.go
@@ -1,12 +1,207 @@
 package textsecure
 
 import (
+	"encoding/binary"
+	"fmt"
+	"io/ioutil"
+	"os"
+
 	log "github.com/Sirupsen/logrus"
+	"github.com/golang/protobuf/proto"
 	"github.com/janimo/textsecure/protobuf"
 )
 
-// handleSyncMessage handles an incoming SyncMessage
+// handleSyncMessage handles an incoming SyncMessage.
 func handleSyncMessage(src string, timestamp uint64, sm *textsecure.SyncMessage) error {
-	log.Debugf("SyncMessage is %+v\n", sm)
+	log.Debugf("SyncMessage recieved at %d", timestamp)
+	if !config.EnableMultiDeviceSync {
+		log.Debugf("Multi-Device sync is disabled. Ignoring message")
+		return nil
+	}
+
+	if sm.GetSent() != nil {
+		return handleSyncSent(sm.GetSent())
+	} else if sm.GetRequest() != nil {
+		return handleSyncRequest(sm.GetRequest())
+	} else if sm.GetRead() != nil {
+		return handleSyncRead(sm.GetRead())
+	} else {
+		log.Errorf("SyncMessage contains no known sync types")
+	}
+
 	return nil
+}
+
+// handleSyncSent handles sync sent messages
+func handleSyncSent(s *textsecure.SyncMessage_Sent) error {
+	dm := s.GetMessage()
+	dest := s.GetDestination()
+	timestamp := s.GetTimestamp()
+
+	if dm == nil {
+		return fmt.Errorf("DataMessage was nil for SyncMessage_Sent")
+	}
+
+	flags, err := handleFlags(dest, dm)
+	if err != nil {
+		return err
+	}
+
+	atts, err := handleAttachments(dm)
+	if err != nil {
+		return err
+	}
+
+	gr, err := handleGroups(dest, dm)
+	if err != nil {
+		return err
+	}
+
+	msg := &Message{
+		source:      dest,
+		message:     dm.GetBody(),
+		attachments: atts,
+		group:       gr,
+		timestamp:   timestamp,
+		flags:       flags,
+	}
+
+	if client.SyncSentHandler != nil {
+		client.SyncSentHandler(msg)
+	}
+
+	return nil
+}
+
+// handleSyncRequestMessage
+func handleSyncRequest(request *textsecure.SyncMessage_Request) error {
+	if request.GetType() == textsecure.SyncMessage_Request_CONTACTS {
+		return sendContactUpdate()
+	} else if request.GetType() == textsecure.SyncMessage_Request_GROUPS {
+		return sendGroupUpdate()
+	}
+
+	return nil
+}
+
+// sendContactUpdate
+func sendContactUpdate() error {
+	log.Debugf("Sending contact SyncMessage")
+
+	lc, err := GetRegisteredContacts()
+	if err != nil {
+		return fmt.Errorf("could not get local contacts: %s", err)
+	}
+
+	tmp, err := ioutil.TempFile(config.StorageDir, "multidevice-contact-update")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name())
+
+	for _, c := range lc {
+		cd := &textsecure.ContactDetails{
+			Number: &c.Tel,
+			Name:   &c.Name,
+			// TODO: handle avatars
+		}
+
+		b, err := proto.Marshal(cd)
+		if err != nil {
+			log.Errorf("Failed to marshal contact details")
+			continue
+		}
+
+		tmp.Write(varint32(len(b)))
+		tmp.Write(b)
+	}
+
+	tmp.Sync()
+	tmp.Seek(0, 0)
+
+	a, err := uploadAttachment(tmp, "application/octet-stream")
+	if err != nil {
+		return err
+	}
+
+	sm := &textsecure.SyncMessage{
+		Contacts: &textsecure.SyncMessage_Contacts{
+			Blob: &textsecure.AttachmentPointer{
+				Id:          &a.id,
+				ContentType: &a.ct,
+				Key:         a.keys,
+			},
+		},
+	}
+
+	_, err = sendSyncMessage(sm)
+	return err
+}
+
+// sendGroupUpdate
+func sendGroupUpdate() error {
+	log.Debugf("Sending group SyncMessage")
+
+	tmp, err := ioutil.TempFile(config.StorageDir, "multidevice-group-update")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name())
+
+	for _, g := range groups {
+		gd := &textsecure.GroupDetails{
+			Id:      g.ID,
+			Name:    &g.Name,
+			Members: g.Members,
+			// XXX add support for avatar
+			// XXX add support for active?
+		}
+
+		b, err := proto.Marshal(gd)
+		if err != nil {
+			log.Errorf("Failed to marshal group details")
+			continue
+		}
+
+		tmp.Write(varint32(len(b)))
+		tmp.Write(b)
+	}
+
+	tmp.Sync()
+	tmp.Seek(0, 0)
+
+	a, err := uploadAttachment(tmp, "application/octet-stream")
+	if err != nil {
+		return err
+	}
+
+	sm := &textsecure.SyncMessage{
+		Groups: &textsecure.SyncMessage_Groups{
+			Blob: &textsecure.AttachmentPointer{
+				Id:          &a.id,
+				ContentType: &a.ct,
+				Key:         a.keys,
+			},
+		},
+	}
+
+	_, err = sendSyncMessage(sm)
+	return err
+}
+
+func handleSyncRead(readMessages []*textsecure.SyncMessage_Read) error {
+	if client.SyncReadHandler != nil {
+		for _, s := range readMessages {
+			client.SyncReadHandler(s.GetSender(), s.GetTimestamp())
+		}
+	}
+
+	return nil
+}
+
+// Encodes a 32bit base 128 variable-length integer and returns the bytes
+func varint32(value int) []byte {
+	buf := make([]byte, binary.MaxVarintLen32)
+	n := binary.PutUvarint(buf, uint64(value))
+	return buf[:n]
 }

--- a/sync.go
+++ b/sync.go
@@ -13,10 +13,6 @@ import (
 // handleSyncMessage handles an incoming SyncMessage.
 func handleSyncMessage(src string, timestamp uint64, sm *textsecure.SyncMessage) error {
 	log.Debugf("SyncMessage recieved at %d", timestamp)
-	if !config.EnableMultiDeviceSync {
-		log.Debugf("Multi-Device sync is disabled. Ignoring message")
-		return nil
-	}
 
 	if sm.GetSent() != nil {
 		return handleSyncSent(sm.GetSent(), timestamp)

--- a/textsecure.go
+++ b/textsecure.go
@@ -221,7 +221,7 @@ type Client struct {
 	MessageHandler      func(*Message)
 	ReceiptHandler      func(string, uint32, uint64)
 	SyncReadHandler     func(string, uint64)
-	SyncSentHandler     func(*Message)
+	SyncSentHandler     func(*Message, uint64)
 	RegistrationDone    func()
 }
 

--- a/textsecure.go
+++ b/textsecure.go
@@ -220,6 +220,8 @@ type Client struct {
 	GetLocalContacts    func() ([]Contact, error)
 	MessageHandler      func(*Message)
 	ReceiptHandler      func(string, uint32, uint64)
+	SyncReadHandler     func(string, uint64)
+	SyncSentHandler     func(*Message)
 	RegistrationDone    func()
 }
 
@@ -373,8 +375,12 @@ func handleMessage(src string, timestamp uint64, b []byte, legacy bool) error {
 	}
 	if dm := content.GetDataMessage(); dm != nil {
 		return handleDataMessage(src, timestamp, dm)
+	} else if sm := content.GetSyncMessage(); sm != nil && config.Tel == src {
+		return handleSyncMessage(src, timestamp, sm)
 	}
-	return handleSyncMessage(src, timestamp, content.GetSyncMessage())
+
+	log.Errorf("Unknown message content received")
+	return nil
 }
 
 // EndSessionFlag signals that this message resets the session

--- a/textsecure.go
+++ b/textsecure.go
@@ -104,6 +104,26 @@ type outgoingMessage struct {
 	flags      uint32
 }
 
+// LinkedDevices returns the list of linked devices
+func LinkedDevices() ([]DeviceInfo, error) {
+	return getLinkedDevices()
+}
+
+// UnlinkDevice removes a linked device
+func UnlinkDevice(id int) error {
+	return unlinkDevice(id)
+}
+
+// NewDeviceVerificationCode returns the verification code for linking devices
+func NewDeviceVerificationCode() (string, error) {
+	return getNewDeviceVerificationCode()
+}
+
+// AddDevice links a new device
+func AddDevice(ephemeralId, publicKey, verificationCode string) error {
+	return addNewDevice(ephemeralId, publicKey, verificationCode)
+}
+
 // SendMessage sends the given text message to the given contact.
 func SendMessage(tel, msg string) (uint64, error) {
 	omsg := &outgoingMessage{

--- a/transport.go
+++ b/transport.go
@@ -36,6 +36,7 @@ func (r *response) Error() string {
 
 type transporter interface {
 	get(url string) (*response, error)
+	del(url string) (*response, error)
 	putJSON(url string, body []byte) (*response, error)
 	putBinary(url string, body []byte) (*response, error)
 }
@@ -88,6 +89,30 @@ func (ht *httpTransporter) get(url string) (*response, error) {
 	}
 
 	log.Debugf("GET %s %d\n", url, r.Status)
+
+	return r, err
+}
+
+func (ht *httpTransporter) del(url string) (*response, error) {
+	req, err := http.NewRequest("DELETE", ht.baseURL+url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if config.UserAgent != "" {
+		req.Header.Set("User-Agent", config.UserAgent)
+	}
+	req.SetBasicAuth(ht.user, ht.pass)
+	resp, err := ht.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	r := &response{}
+	if resp != nil {
+		r.Status = resp.StatusCode
+		r.Body = resp.Body
+	}
+
+	log.Debugf("DELETE %s %d\n", url, r.Status)
 
 	return r, err
 }


### PR DESCRIPTION
First thanks for the excellent library. This pull request is a first cut at supporting device linking. It's based off the code in libsignal-service-java. Added support for fetching linked devices, linking a new device, and removing a device. I did some initial testing using Signal-Desktop in a development environment and seems to be working (aside from contact syncing). I  added an example of how the client API would work into `cmd/textsecure/main.go` command. Basically, you fire up Signal-Desktop scan the QR code and pass in the URL:

    $ textsecure -linkdevice 'tsdevice:/?uuid=xxx&pub_key=yyy'

If all goes well, to see linked devices you can run:

    $ ./textsecure -showdevices

Currently, it looks like Open Whisper Systems only supports device linking for Android, so it may be worth contacting them at some point to ensure this wouldn't be in violation of their terms, etc.

That all being said, I am in no way a crypto expert but hope this PR can at least serve as starting point. Feedback welcome!

Thanks again for the awesome work on this library.
